### PR TITLE
Fixed: Bug

### DIFF
--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -13,7 +13,7 @@ export default function useSearch (setLocalState) {
 
   const handleKeyPress = (event) => {
     if (event.key === 'Enter') {
-      if (search !== '') {
+      if (search.trim() !== '') {
         fetchPokemon(search.toLowerCase())
           .then(
             data => {


### PR DESCRIPTION
Bug: Again the bug is app crashed when user press enter with a space or spaces in search input.
Fix: Trim down the trailing and leading spaces from search